### PR TITLE
callback PlaybackStatusCompat.STATE_ERROR when media not found

### DIFF
--- a/app/src/main/java/com/sjn/stamp/media/playback/LocalPlayback.java
+++ b/app/src/main/java/com/sjn/stamp/media/playback/LocalPlayback.java
@@ -174,12 +174,18 @@ class LocalPlayback implements Playback, AudioManager.OnAudioFocusChangeListener
 
         if (mState == PlaybackStateCompat.STATE_PAUSED && !mediaHasChanged && mMediaPlayer != null) {
             configMediaPlayerState();
+        } else if (item.getDescription().getMediaUri() == null) {
+            mState = PlaybackStateCompat.STATE_ERROR;
+            if (mCallback != null) {
+                mCallback.onPlaybackStatusChanged(mState);
+                mCallback.onError("Media not found.");
+            }
         } else {
             mState = PlaybackStateCompat.STATE_STOPPED;
             relaxResources(false); // release everything except MediaPlayer
             MediaMetadataCompat track = mMusicProvider.getMusicByMediaId(item.getDescription().getMediaId());
 
-            String source = track == null ? item.getDescription().getMediaUri().toString() : track.getString(MusicProviderSource.CUSTOM_METADATA_TRACK_SOURCE);
+            String source = (track == null) ? item.getDescription().getMediaUri().toString() : track.getString(MusicProviderSource.CUSTOM_METADATA_TRACK_SOURCE);
             /*
             if (source != null) {
                 source = source.replaceAll(" ", "%20"); // Escape spaces for URLs
@@ -192,7 +198,7 @@ class LocalPlayback implements Playback, AudioManager.OnAudioFocusChangeListener
                 mState = PlaybackStateCompat.STATE_BUFFERING;
 
                 mMediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-                DataSourceHelper.setMediaPlayerDataSource(mContext, mMediaPlayer, source.toString());
+                DataSourceHelper.setMediaPlayerDataSource(mContext, mMediaPlayer, source);
 
                 // Starts preparing the media player in the background. When
                 // it's done, it will call our OnPreparedListener (that is,


### PR DESCRIPTION
FIX #64 

> Also, you have to increment mCurrentIndex and try to play next music like following.

`PlaybackManager.handlePlayRequest()` is called not only "when a music is completed and try to play next" but also "when user touches a song on ListView".
It's a little confusing if wrong song played when user touches a song on ListView.

And it's much to do above process only "when a music is completed and try to play next".
